### PR TITLE
Rebuild for aarch64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   number: 0
   # trigger 1
   # neither on Windows 32-bit nor on s390x there is right now arrow support
-  skip: true  # [win32 or s390x]
+  skip: true  # [win32 or s390x or py==310]
   script:
     - export SF_NO_COPY_ARROW_LIB=1              # [unix]
     - export SF_ARROW_LIBDIR="${PREFIX}/lib"     # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@ source:
     - 0001-drop-pyarrow-version-numbers.patch
 
 build:
-  number: 0
-  # trigger 1
+  number: 1
   # neither on Windows 32-bit nor on s390x there is right now arrow support
   skip: true  # [win32 or s390x or py==310]
   script:
@@ -77,7 +76,6 @@ test:
   imports:
     - snowflake
     - snowflake.connector
-    - snowflake.connector.arrow_iterator  # [unix]
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  # trigger 1
   # neither on Windows 32-bit nor on s390x there is right now arrow support
   skip: true  # [win32 or s390x]
   script:


### PR DESCRIPTION
Skip building for python 3.10 because of UnsatisfiableError. I guess the issue is with arrow-cpp 4.0.1 → pyarrow 4.0.1 and python 3.10. 