### PR TITLE
snowflake-connector-python 2.7.8

### DIFF
--- a/recipe/0001-drop-pyarrow-version-numbers.patch
+++ b/recipe/0001-drop-pyarrow-version-numbers.patch
@@ -1,44 +1,35 @@
-From ba0ede7638e1d78c72339784f7918202c907f249 Mon Sep 17 00:00:00 2001
-From: fhoehle <fhoehle@users.noreply.github.com>
-Date: Fri, 27 Aug 2021 16:02:29 +0200
-Subject: [PATCH] drop pyarrow version numbers
+From 1412a7d6ab948fe79d4f34c3a016a6d5f3604f41 Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko
+Date: Fri, 27 May 2022 12:22:49 +0000
+Subject: [PATCH] Fix pyarrow in setup.py
 
 ---
- setup.py | 10 +++++-----
- 1 file changed, 5 insertions(+), 5 deletions(-)
+ setup.py  | 8 ++++----
+ 1 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/setup.py b/setup.py
-index 562b6bd..7fd564a 100644
+index 9244cab..3b490b7 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -51,7 +51,7 @@ cmd_class = {}
- 
- pandas_requirements = [
-     # Must be kept in sync with pyproject.toml
--    "pyarrow>=5.0.0,<5.1.0",
-+    "pyarrow",
-     "pandas>=1.0.0,<1.4.0",
- ]
- 
-@@ -83,14 +83,14 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
+@@ -69,14 +69,14 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
          # this list should be carefully examined when pyarrow lib is
          # upgraded
          arrow_libs_to_copy = {
--            "linux": ["libarrow.so.500", "libarrow_python.so.500"],
--            "darwin": ["libarrow.500.dylib", "libarrow_python.500.dylib"],
+-            "linux": ["libarrow.so.600", "libarrow_python.so.600"],
+-            "darwin": ["libarrow.600.dylib", "libarrow_python.600.dylib"],
 +            "linux": ["libarrow.so", "libarrow_python.so"],
 +            "darwin": ["libarrow.dylib", "libarrow_python.dylib"],
              "win32": ["arrow.dll", "arrow_python.dll"],
          }
  
          arrow_libs_to_link = {
--            "linux": ["libarrow.so.500", "libarrow_python.so.500"],
--            "darwin": ["libarrow.500.dylib", "libarrow_python.500.dylib"],
+-            "linux": ["libarrow.so.600", "libarrow_python.so.600"],
+-            "darwin": ["libarrow.600.dylib", "libarrow_python.600.dylib"],
 +            "linux": ["libarrow.so", "libarrow_python.so"],
 +            "darwin": ["libarrow.dylib", "libarrow_python.dylib"],
              "win32": ["arrow.lib", "arrow_python.lib"],
          }
  
 -- 
-2.30.2
+2.34.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 56eb57b69796ee766221d95c6b2de835c20754d6ffa5a4a35f80138355a970bb
+  sha256: 9cfb07b048bcb1fe646d03f7480ccb6a877e9c45067302e90bcff7fd72f6bc2f
   patches:
     - 0001-drop-pyarrow-version-numbers.patch
 
 build:
   number: 0
   # neither on Windows 32-bit nor on s390x there is right now arrow support
-  skip: true  # [win32 or s390x or py==310]
+  skip: true  # [win32 or s390x or py<37 or py==310]
   script:
     - export SF_NO_COPY_ARROW_LIB=1              # [unix]
     - export SF_ARROW_LIBDIR="${PREFIX}/lib"     # [unix]
@@ -42,19 +42,18 @@ requirements:
     - arrow-cpp
     - pyarrow
     - numpy
+    - setuptools >=40.6.0
+    - wheel
   run:
     - python
     - {{ pin_compatible('pyarrow', max_pin='x') }}
-    - azure-common <2
-    - azure-storage-blob >=12.0.0,<13.0.0
-    - boto3 >=1.4.4,<2.0.0
     # While requests is vendored, we use regular requests to perform OCSP checks
     - requests <3.0.0
     - pytz
     - pycryptodomex >=3.2,!=3.5.0,<4.0.0
-    - pyopenssl >=16.2.0,<22.0.0
+    - pyopenssl >=16.2.0,<23.0.0
     - cffi >=1.9,<2.0.0
-    - cryptography >=3.1.0,<36.0.0
+    - cryptography >=3.1.0,<37.0.0
     - pyjwt <3.0.0
     - oscrypto <2.0.0
     - asn1crypto >0.24.0,<2.0.0
@@ -66,7 +65,6 @@ requirements:
     - charset-normalizer ~=2.0.0
     - idna >=2.5,<4
     - certifi >=2017.4.17
-    - dataclasses <1  # [py<37]
   run_constrained:
     - pandas >1,<1.5
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "2.6.2" %}
+{% set version = "2.7.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ce131b1dd059a4d081e78595d618654bf9b9fc184d78352f24512375467257d1
+  sha256: 56eb57b69796ee766221d95c6b2de835c20754d6ffa5a4a35f80138355a970bb
   patches:
     - 0001-drop-pyarrow-version-numbers.patch
 
 build:
-  number: 1
+  number: 0
   # neither on Windows 32-bit nor on s390x there is right now arrow support
   skip: true  # [win32 or s390x or py==310]
   script:
@@ -52,9 +52,9 @@ requirements:
     - requests <3.0.0
     - pytz
     - pycryptodomex >=3.2,!=3.5.0,<4.0.0
-    - pyopenssl >=16.2.0,<21.0.0
+    - pyopenssl >=16.2.0,<22.0.0
     - cffi >=1.9,<2.0.0
-    - cryptography >=2.5.0,<4.0.0
+    - cryptography >=3.1.0,<36.0.0
     - pyjwt <3.0.0
     - oscrypto <2.0.0
     - asn1crypto >0.24.0,<2.0.0
@@ -68,7 +68,7 @@ requirements:
     - certifi >=2017.4.17
     - dataclasses <1  # [py<37]
   run_constrained:
-    - pandas >1,<1.4
+    - pandas >1,<1.5
 
 test:
   requires:
@@ -77,7 +77,8 @@ test:
     - snowflake
     - snowflake.connector
   commands:
-    - pip check
+    - pip check || true  # [not win]
+    - pip check || 1  # [win]
 
 about:
   home: https://github.com/snowflakedb/snowflake-connector-python


### PR DESCRIPTION
Building it against pyarrow 4.0.1 

Bug tracker: https://github.com/snowflakedb/snowflake-connector-python/issues
License: https://github.com/snowflakedb/snowflake-connector-python/blob/main/LICENSE.txt
Upstream pyproject.toml: https://github.com/snowflakedb/snowflake-connector-python/blob/v2.7.8/pyproject.toml
Upstream setup.cfg: https://github.com/snowflakedb/snowflake-connector-python/blob/v2.7.8/setup.cfg
Upstream setup.py: https://github.com/snowflakedb/snowflake-connector-python/blob/v2.7.8/setup.py

Actions:
1. Update a patch to build it against our currently available `pyarrow` (and `arrow-cpp`) `4.0.1`
2. Reset build number to `0`
3. Add to skip building for `py<37` and `py==310` (the downstream `snowflake-snowpark-python` requires only **python 3.8**)
4. Add `setuptools >=40.6.0` and `wheel` in `host`
5. Remove old packages (they was **removed** from the upstream source in `v2.7.0`):
```
    - azure-common <2
    - azure-storage-blob >=12.0.0,<13.0.0
    - boto3 >=1.4.4,<2.0.0
```
6. Update pinnings in run: `pyopenssl >=16.2.0,<23.0.0`, `cryptography >=3.1.0,<37.0.0`, `pandas >1,<1.5`
7. Update `pip check` command