### PR TITLE
bump to 2.7.11

### DIFF
--- a/recipe/0001-drop-pyarrow-version-numbers.patch
+++ b/recipe/0001-drop-pyarrow-version-numbers.patch
@@ -1,16 +1,3 @@
-diff --git a/setup.cfg b/setup.cfg
-index 2bd1e4b..9b19872 100644
---- a/setup.cfg
-+++ b/setup.cfg
-@@ -56,7 +56,7 @@ install_requires =
-     idna>=2.5,<4
-     urllib3>=1.21.1,<1.27
-     certifi>=2017.4.17
--    typing_extensions>=4.3,<5
-+    typing_extensions>=4,<5
- include_package_data = True
- package_dir =
-     =src
 diff --git a/setup.py b/setup.py
 index d4ccdb7..dc65b49 100644
 --- a/setup.py

--- a/recipe/0001-drop-pyarrow-version-numbers.patch
+++ b/recipe/0001-drop-pyarrow-version-numbers.patch
@@ -1,61 +1,34 @@
-From 8e0daac205f909e73017d4ae3fc6f2a382378859 Mon Sep 17 00:00:00 2001
-From: Andrew Achkar <hajapy@users.noreply.github.com>
-Date: Sat, 30 Apr 2022 10:16:22 -0400
-Subject: [PATCH] drop pyarrow version numbers
-
----
- pyproject.toml | 2 +-
- setup.cfg      | 2 +-
- setup.py       | 8 ++++----
- 3 files changed, 6 insertions(+), 6 deletions(-)
-
-diff --git a/pyproject.toml b/pyproject.toml
-index ad1f850..16bc0b3 100644
---- a/pyproject.toml
-+++ b/pyproject.toml
-@@ -6,7 +6,7 @@ requires = [
-     "wheel",
-     "cython",
-     # Must be kept in sync with the `setup_requirements` in `setup.cfg`
--    "pyarrow>=6.0.0,<6.1.0",
-+    "pyarrow",
- ]
-
- [tool.cibuildwheel]
-diff --git a/setup.cfg b/setup.cfg
-index 3d906e0..3180e1b 100644
---- a/setup.cfg
-+++ b/setup.cfg
-@@ -89,6 +89,6 @@ development =
-     pytzdata
- pandas =
-     pandas>=1.0.0,<1.5.0
--    pyarrow>=6.0.0,<6.1.0
-+    pyarrow
- secure-local-storage =
-     keyring!=16.1.0,<24.0.0
 diff --git a/setup.py b/setup.py
-index 9244cab..3b490b7 100644
+index d4ccdb7..53472f9 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -69,14 +69,14 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
+@@ -71,21 +71,21 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
          # this list should be carefully examined when pyarrow lib is
          # upgraded
          arrow_libs_to_copy = {
--            "linux": ["libarrow.so.600", "libarrow_python.so.600"],
--            "darwin": ["libarrow.600.dylib", "libarrow_python.600.dylib"],
-+            "linux": ["libarrow.so", "libarrow_python.so"],
-+            "darwin": ["libarrow.dylib", "libarrow_python.dylib"],
-             "win32": ["arrow.dll", "arrow_python.dll"],
+-            "linux": ["libarrow.so.800", "libarrow_python.so.800", "libparquet.so.800"],
++            "linux": ["libarrow.so", "libarrow_python.so", "libparquet.so"],
+             "darwin": [
+-                "libarrow.800.dylib",
+-                "libarrow_python.800.dylib",
+-                "libparquet.800.dylib",
++                "libarrow.dylib",
++                "libarrow_python.dylib",
++                "libparquet.dylib",
+             ],
+             "win32": ["arrow.dll", "arrow_python.dll", "parquet.dll"],
          }
-
+ 
          arrow_libs_to_link = {
--            "linux": ["libarrow.so.600", "libarrow_python.so.600"],
--            "darwin": ["libarrow.600.dylib", "libarrow_python.600.dylib"],
-+            "linux": ["libarrow.so", "libarrow_python.so"],
-+            "darwin": ["libarrow.dylib", "libarrow_python.dylib"],
-             "win32": ["arrow.lib", "arrow_python.lib"],
+-            "linux": ["libarrow.so.800", "libarrow_python.so.800", "libparquet.so.800"],
++            "linux": ["libarrow.so", "libarrow_python.so", "libparquet.so"],
+             "darwin": [
+-                "libarrow.800.dylib",
+-                "libarrow_python.800.dylib",
+-                "libparquet.800.dylib",
++                "libarrow.dylib",
++                "libarrow_python.dylib",
++                "libparquet.dylib",
+             ],
+             "win32": ["arrow.lib", "arrow_python.lib", "parquet.lib"],
          }
-
---
-2.32.0 (Apple Git-132)

--- a/recipe/0001-drop-pyarrow-version-numbers.patch
+++ b/recipe/0001-drop-pyarrow-version-numbers.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index d4ccdb7..53472f9 100644
+index d4ccdb7..e273238 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -71,21 +71,21 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
@@ -32,3 +32,17 @@ index d4ccdb7..53472f9 100644
              ],
              "win32": ["arrow.lib", "arrow_python.lib", "parquet.lib"],
          }
+@@ -169,9 +169,11 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
+             link_lib = self.arrow_libs_to_link[sys.platform]
+             ret = []
+ 
++            libdir = self._get_arrow_lib_dir()
++            assert os.path.exists(libdir), f"COULD NOT FIND DIRECTORY: {libdir}"
+             for lib in link_lib:
+-                source = f"{self._get_arrow_lib_dir()}/{lib}"
+-                assert os.path.exists(source)
++                source = f"{libdir}/{lib}"
++                assert os.path.exists(source), '\n'.join([f"COULD NOT FIND LIBRARY: {source}"] + os.listdir(libdir))
+                 ret.append(source)
+ 
+             return ret

--- a/recipe/0001-drop-pyarrow-version-numbers.patch
+++ b/recipe/0001-drop-pyarrow-version-numbers.patch
@@ -1,22 +1,37 @@
+diff --git a/setup.cfg b/setup.cfg
+index 2bd1e4b..9b19872 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -56,7 +56,7 @@ install_requires =
+     idna>=2.5,<4
+     urllib3>=1.21.1,<1.27
+     certifi>=2017.4.17
+-    typing_extensions>=4.3,<5
++    typing_extensions>=4,<5
+ include_package_data = True
+ package_dir =
+     =src
 diff --git a/setup.py b/setup.py
-index d4ccdb7..e273238 100644
+index d4ccdb7..dc65b49 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -71,21 +71,21 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
+@@ -69,23 +69,19 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
+ 
+         # list of libraries that will be bundled with python connector,
          # this list should be carefully examined when pyarrow lib is
-         # upgraded
+-        # upgraded
++        # upgraded. For conda, we don't vendor at all
          arrow_libs_to_copy = {
 -            "linux": ["libarrow.so.800", "libarrow_python.so.800", "libparquet.so.800"],
-+            "linux": ["libarrow.so", "libarrow_python.so", "libparquet.so"],
-             "darwin": [
+-            "darwin": [
 -                "libarrow.800.dylib",
 -                "libarrow_python.800.dylib",
 -                "libparquet.800.dylib",
-+                "libarrow.dylib",
-+                "libarrow_python.dylib",
-+                "libparquet.dylib",
-             ],
-             "win32": ["arrow.dll", "arrow_python.dll", "parquet.dll"],
+-            ],
+-            "win32": ["arrow.dll", "arrow_python.dll", "parquet.dll"],
++            "linux": [],
++            "darwin": [],
++            "win32": [],
          }
  
          arrow_libs_to_link = {
@@ -32,17 +47,3 @@ index d4ccdb7..e273238 100644
              ],
              "win32": ["arrow.lib", "arrow_python.lib", "parquet.lib"],
          }
-@@ -169,9 +169,11 @@ if _ABLE_TO_COMPILE_EXTENSIONS:
-             link_lib = self.arrow_libs_to_link[sys.platform]
-             ret = []
- 
-+            libdir = self._get_arrow_lib_dir()
-+            assert os.path.exists(libdir), f"COULD NOT FIND DIRECTORY: {libdir}"
-             for lib in link_lib:
--                source = f"{self._get_arrow_lib_dir()}/{lib}"
--                assert os.path.exists(source)
-+                source = f"{libdir}/{lib}"
-+                assert os.path.exists(source), '\n'.join([f"COULD NOT FIND LIBRARY: {source}"] + os.listdir(libdir))
-                 ret.append(source)
- 
-             return ret

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: 0
-  # neither on Windows 32-bit nor on s390x there is right now arrow support
+  # no arrow support on win-32 or s390x
   skip: true  # [win32 or s390x or py<37]
   script:
     - export SF_NO_COPY_ARROW_LIB=1              # [unix]
@@ -43,15 +43,17 @@ requirements:
     - python
     - pip
     - cython
-    - arrow-cpp
+    # Snowflake asserts that they rely on only a
+    # small subset of the arrow-cpp API that has
+    # been stable since 0.17
+    - arrow-cpp >=0.17
     - pyarrow
     - numpy
     - setuptools >=40.6.0
     - wheel
   run:
     - python
-    # the unpatched wheel build vendors arrow-cpp
-    # this recipe breaks that out
+    - pyarrow
     - {{ pin_compatible('arrow-cpp', max_pin='x') }}
     - asn1crypto >0.24.0,<2.0.0
     - cffi >=1.9,<2.0.0
@@ -67,10 +69,9 @@ requirements:
     - idna >=2.5,<4
     - urllib3 >=1.21.1,<1.27
     - certifi >=2017.4.17
-    - typing-extensions >=4,<5
+    - typing-extensions >=4.3.0,<5
   run_constrained:
     - pandas >1,<1.5
-    - {{ pin_compatible('pyarrow', max_pin='x') }}
     - keyring !=16.1.0,<24.0.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "2.7.8" %}
+{% set version = "2.7.11" %}
+{% set sha256 = "e577da63791dbd299629670b199510015361b5e863ff37e083224e39c2f9e73b" %}
 
 package:
   name: {{ name|lower }}
@@ -8,14 +9,14 @@ package:
 source:
   url: https://codeload.github.com/snowflakedb/{{ name }}/tar.gz/v{{ version }}
   fn: {{ name }}-{{ version }}.tar.gz
-  sha256: 56eb57b69796ee766221d95c6b2de835c20754d6ffa5a4a35f80138355a970bb
+  sha256: {{ sha256 }}
   patches:
     - 0001-drop-pyarrow-version-numbers.patch
 
 build:
   number: 0
   # neither on Windows 32-bit nor on s390x there is right now arrow support
-  skip: true  # [win32 or s390x or py<37 or py==310]
+  skip: true  # [win32 or s390x or py<37]
   script:
     - export SF_NO_COPY_ARROW_LIB=1              # [unix]
     - export SF_ARROW_LIBDIR="${PREFIX}/lib"     # [unix]
@@ -68,6 +69,8 @@ requirements:
     - certifi >=2017.4.17
   run_constrained:
     - pandas >1,<1.5
+    - pyarrow >=8.0.0,<8.1.0
+    - keyring !=16.1.0,<24.0.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
     - export SF_ARROW_LIBDIR="${PREFIX}/lib"     # [unix]
     - export ENABLE_EXT_MODULES=true             # [unix]
     - set SF_NO_COPY_ARROW_LIB=1                 # [win]
-    - set SF_ARROW_LIBDIR="%LIBRARY_BIN%"        # [win]
+    - set "SF_ARROW_LIBDIR=%PREFIX%\Library"     # [win]
     - set ENABLE_EXT_MODULES=1                   # [win]
     - {{ PYTHON }} -m pip install . --no-deps -vvv
   entry_points:
@@ -30,6 +30,8 @@ build:
     - snowflake-dump-ocsp-response-cache = snowflake.connector.tool.dump_ocsp_response_cache:main
     - snowflake-dump-certs = snowflake.connector.tool.dump_certs:main
     - snowflake-export-certs = snowflake.connector.tool.export_certs:main
+  ignore_run_exports:
+    - arrow-cpp
 
 requirements:
   build:
@@ -48,17 +50,17 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible('pyarrow', max_pin='x') }}
+    - {{ pin_compatible('arrow-cpp', max_pin='x') }}
     # While requests is vendored, we use regular requests to perform OCSP checks
-    - requests <3.0.0
-    - pytz
-    - pycryptodomex >=3.2,!=3.5.0,<4.0.0
-    - pyopenssl >=16.2.0,<23.0.0
+    - asn1crypto >0.24.0,<2.0.0
     - cffi >=1.9,<2.0.0
     - cryptography >=3.1.0,<37.0.0
-    - pyjwt <3.0.0
     - oscrypto <2.0.0
-    - asn1crypto >0.24.0,<2.0.0
+    - pyopenssl >=16.2.0,<23.0.0
+    - pycryptodomex >=3.2,!=3.5.0,<4.0.0
+    - pyjwt <3.0.0
+    - pytz
+    - requests <3.0.0
     # A functioning pkg_resources.working_set.by_key and pkg_resources.Requirement is
     # required. Python 3.6 was released at the end of 2016. setuptools 34.0.0 was released
     # in early 2017, so we pick this version as a reasonably modern base.
@@ -66,10 +68,12 @@ requirements:
     # requests requirements
     - charset-normalizer ~=2.0.0
     - idna >=2.5,<4
+    - urllib3 >=1.21.1,<1.27
     - certifi >=2017.4.17
+    - typing_extensions >=4.3,<5
   run_constrained:
     - pandas >1,<1.5
-    - pyarrow >=8.0.0,<8.1.0
+    - {{ pin_compatible('pyarrow', max_pin='x') }}
     - keyring !=16.1.0,<24.0.0
 
 test:
@@ -78,6 +82,7 @@ test:
   imports:
     - snowflake
     - snowflake.connector
+    - snowflake.connector.arrow_iterator
   commands:
     - pip check || true  # [not win]
     - pip check || 1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
     - export SF_ARROW_LIBDIR="${PREFIX}/lib"     # [unix]
     - export ENABLE_EXT_MODULES=true             # [unix]
     - set SF_NO_COPY_ARROW_LIB=1                 # [win]
-    - set "SF_ARROW_LIBDIR=%LIBRARY_LIB%"        # [win]
+    - set SF_ARROW_LIBDIR="%LIBRARY_BIN%"        # [win]
     - set ENABLE_EXT_MODULES=1                   # [win]
     - {{ PYTHON }} -m pip install . --no-deps -vvv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,10 +43,7 @@ requirements:
     - python
     - pip
     - cython
-    # Snowflake asserts that they rely on only a
-    # small subset of the arrow-cpp API that has
-    # been stable since 0.17
-    - arrow-cpp >=0.17
+    - arrow-cpp >=8,<9
     - pyarrow
     - numpy
     - setuptools >=40.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,8 +50,9 @@ requirements:
     - wheel
   run:
     - python
+    # the unpatched wheel build vendors arrow-cpp
+    # this recipe breaks that out
     - {{ pin_compatible('arrow-cpp', max_pin='x') }}
-    # While requests is vendored, we use regular requests to perform OCSP checks
     - asn1crypto >0.24.0,<2.0.0
     - cffi >=1.9,<2.0.0
     - cryptography >=3.1.0,<37.0.0
@@ -61,16 +62,12 @@ requirements:
     - pyjwt <3.0.0
     - pytz
     - requests <3.0.0
-    # A functioning pkg_resources.working_set.by_key and pkg_resources.Requirement is
-    # required. Python 3.6 was released at the end of 2016. setuptools 34.0.0 was released
-    # in early 2017, so we pick this version as a reasonably modern base.
     - setuptools >34.0.0
-    # requests requirements
-    - charset-normalizer ~=2.0.0
+    - charset-normalizer >=2,<3
     - idna >=2.5,<4
     - urllib3 >=1.21.1,<1.27
     - certifi >=2017.4.17
-    - typing_extensions >=4.3,<5
+    - typing-extensions >=4,<5
   run_constrained:
     - pandas >1,<1.5
     - {{ pin_compatible('pyarrow', max_pin='x') }}


### PR DESCRIPTION
- Bumped version and sha256
- Added additional dependencies
- Simplified patch
- Unskipped Python 3.10
- Removed the vendoring of pyarrow libraries by patching setup.py

This last bullet is pretty important; see the inline comments below. For reference I spoke with the snowflake developers to confirm this approach will work, and added an additional test to verify it. Our older packages aren't _broken_, and do not need to be rebuilt, but this is definitely a better way to go moving forward.