### PR TITLE
bump to 2.7.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,7 @@ requirements:
     - urllib3 >=1.21.1,<1.27
     - certifi >=2017.4.17
     - typing-extensions >=4.3.0,<5
+    - filelock>=3.5,<4
   run_constrained:
     - pandas >1,<1.5
     - keyring !=16.1.0,<24.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,8 +80,7 @@ test:
     - snowflake.connector
     - snowflake.connector.arrow_iterator
   commands:
-    - pip check || true  # [not win]
-    - pip check || 1  # [win]
+    - pip check
 
 about:
   home: https://github.com/snowflakedb/snowflake-connector-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "2.7.11" %}
-{% set sha256 = "e577da63791dbd299629670b199510015361b5e863ff37e083224e39c2f9e73b" %}
+{% set version = "2.7.12" %}
+{% set sha256 = "80d9a43ff29dfbcdc5d40d52c469db1ae47eff8b276e60b63deee674676bea74" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Simple version bump.
New dependency on filelock; all other dependencies identical:
https://github.com/snowflakedb/snowflake-connector-python/blob/main/setup.cfg#L60
The refactoring investment for 2.7.11 pays off :-)