### PR TITLE
snowflake-connector-python 3.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower|replace("-","_") }}-{{ version }}.tar.gz
-  sha256: b9214da76ce72fff8eb60066fde6b9ba7f58a055d68ffe1e7a9b1034f57a34b4
+  url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 695992d4540379a8f3a8d3157eadecf3a5fe606e85c424a3080b10b93a3c429c
   
 build:
   number: 0
@@ -55,6 +55,17 @@ requirements:
     - pandas >=1.0.0,<3.0.0
     - keyring >=23.1.0,<25.0.0
 
+# ignore these unit tests because they use relative imports
+# or not found modules (existing but not well configured).
+{% set tests_to_ignore = " --ignore=test/unit/test_configmanager.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_connection.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_encryption_util.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_error_arrow_stream.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_result_batch.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_s3_util.py" %}
+# ignore this test because it takes a lot (retry/timeout network tests)
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_retry_network.py" %}
+
 test:
   imports:
     - snowflake
@@ -62,8 +73,13 @@ test:
     - snowflake.connector.nanoarrow_arrow_iterator
   requires:
     - pip
+    - pytest
+  source_files:
+    - test/unit
+    - test/data/cert_tests/incomplete-chain.pem
   commands:
     - pip check
+    - pytest -v test/unit {{ tests_to_ignore }}
 
 about:
   home: https://github.com/snowflakedb/snowflake-connector-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,6 +66,13 @@ requirements:
 # ignore this test because it takes a lot (retry/timeout network tests)
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_retry_network.py" %}
 
+{% set tests_to_deselect = "" %}
+# linux: deselect the following tests because file permissions 
+# will not be set correctly and with DID NOT RAISE PermissionError
+{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_cache.py::TestSFDictFileCache::test_read_only" %}        # [linux]
+{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_easy_logging.py::test_config_file_inaccessible_path" %}  # [linux]
+{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_put_get.py::test_put_error" %}                           # [linux]
+
 test:
   imports:
     - snowflake
@@ -79,7 +86,7 @@ test:
     - test/data/cert_tests/incomplete-chain.pem
   commands:
     - pip check
-    - pytest -v test/unit {{ tests_to_ignore }}
+    - pytest -v test/unit {{ tests_to_ignore }} {{ tests_to_deselect }}
 
 about:
   home: https://github.com/snowflakedb/snowflake-connector-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,7 @@ requirements:
 
 {% set tests_to_deselect = "" %}
 # linux: deselect the following tests because file permissions 
-# will not be set correctly and with DID NOT RAISE PermissionError
+# will not be set correctly and fail with DID NOT RAISE PermissionError
 {% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_cache.py::TestSFDictFileCache::test_read_only" %}        # [linux]
 {% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_easy_logging.py::test_config_file_inaccessible_path" %}  # [linux]
 {% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_put_get.py::test_put_error" %}                           # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "3.10.0" %}
+{% set version = "3.10.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower|replace("-","_") }}-{{ version }}.tar.gz
-  sha256: 7c7438e958753bd1174b73581d77c92b0b47a86c38d8ea0ba1ea23c442eb8e75
+  sha256: b9214da76ce72fff8eb60066fde6b9ba7f58a055d68ffe1e7a9b1034f57a34b4
   
 build:
   number: 0


### PR DESCRIPTION
snowflake-connector-python 3.10.1

**Destination channel:** defaults

### Links

- [PKG-4828]
- dev_url (pypi): https://github.com/snowflakedb/snowflake-connector-python/tree/v3.10.1
- 3.10.0...3.10.1 compare: https://github.com/snowflakedb/snowflake-connector-python/compare/v3.10.0...v3.10.1
- conda-forge: https://github.com/conda-forge/snowflake-connector-python-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/snowflake-connector-python/3.10.1
- pypi inspector: https://inspector.pypi.io/project/snowflake-connector-python/3.10.1

### Explanation of changes:

- bump version, same dependencies
- switch to GH release archive to include tests
- [add upstream unit tests](https://github.com/AnacondaRecipes/snowflake-connector-python-feedstock/pull/19/commits/a1cccb0f6f4cc8583935c1c604642f0b4c1b53b4)
- ignore or deselect few tests (see comments in the recipe)
- I did not unvendor `requests` or `urllib3` because they did modify them and did some monkey-patching.


[PKG-4828]: https://anaconda.atlassian.net/browse/PKG-4828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ