### PR TITLE
snowflake-connector-python 3.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "3.11.0" %}
+{% set version = "3.12.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   # use GH release sources to use tests
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 51bf7f17db2303ce470928a85eb15c781a3219c035b2cb7643c779ab918a9f99
+  sha256: bf461965a92a1281a642d24a60005228e12f9782b0a943a141142f94d5d3cbc2
   
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - tomlkit
   run_constrained:
     - pandas >=1.0.0,<3.0.0
-    - keyring >=23.1.0,<25.0.0
+    - keyring >=23.1.0,<26.0.0
 
 # ignore these unit tests because they use relative imports
 # or not found modules (existing but not well configured).


### PR DESCRIPTION
snowflake-connector-python 3.12.0

**Destination channel:** defaults

### Links

- [PKG-5405]
- dev_url (pypi): https://github.com/snowflakedb/snowflake-connector-python/tree/v3.12.0 
- [v3.12.1...v3.11.0](https://github.com/snowflakedb/snowflake-connector-python/compare/v3.12.0...v3.11.0) diff: [Comparing v3.10.1...v3.11.0 · snowflakedb/snowflake-connector-python](https://github.com/snowflakedb/snowflake-connector-python/compare/v3.10.1...v3.11.0) 
- conda-forge: https://github.com/conda-forge/snowflake-connector-python-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/snowflake-connector-python/3.12.0/ 
- pypi inspector: https://inspector.pypi.io/project/snowflake-connector-python/3.12.0/

### Explanation of changes:

- bump version


[PKG-5405]: https://anaconda.atlassian.net/browse/PKG-5405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ