### PR TITLE
snowflake-connector-python 3.12.1 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @fhoehle @hajapy @mariusvniekerk @talues @xhochy
+* @AnacondaRecipes/psubs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "3.12.0" %}
+{% set version = "3.12.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,10 +8,10 @@ package:
 source:
   # use GH release sources to use tests
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: bf461965a92a1281a642d24a60005228e12f9782b0a943a141142f94d5d3cbc2
+  sha256: 976f25a4f60714b7fe53778ac0872a69db1becb1d9a5271d7d691f225bdce1a1
   
 build:
-  number: 0
+  number: 100
   # s390x not needed for snowflake
   skip: true  # [s390x or py<38]
   script:
@@ -36,7 +36,7 @@ requirements:
     - python
     - asn1crypto >0.24.0,<2.0.0
     - cffi >=1.9,<2.0.0
-    - cryptography >=3.1.0,<43.0.0
+    - cryptography >=3.1.0
     - pyopenssl >=16.2.0,<25.0.0
     - pyjwt <3.0.0
     - pytz


### PR DESCRIPTION
snowflake-connector-python 3.12.1 

**Destination channel:** Defaults

### Links

- [PKG-5551]
- dev_url:        https://github.com/snowflakedb/snowflake-connector-python/tree/v3.12.1
- conda_forge:    https://github.com/conda-forge/snowflake-connector-python-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/snowflake-connector-python/3.12.0/
- pypi inspector: https://inspector.pypi.io/project/snowflake-connector-python/3.12.1/

### Explanation of changes:

- 3.12.1 build
- changed CODEOWNERS


[PKG-5551]: https://anaconda.atlassian.net/browse/PKG-5551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ