### PR TITLE
snowflake-connector-python 3.12.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "3.12.2" %}
+{% set version = "3.12.3" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   # use GH release sources to use tests
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 910938d7d517b41829bbc06c24e5d8a154794d02c66420a85fdadc76e7f3021b
+  sha256: 596832b7ecde1cef46d1aaab61f2b38783509b1a4dd91df18645184f762b73ae
   
 build:
   number: 100
@@ -91,6 +91,7 @@ test:
     - test/data/cert_tests/incomplete-chain.pem
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest -v test/unit {{ tests_to_ignore }} {{ tests_to_deselect }}
 
 about:


### PR DESCRIPTION
snowflake-connector-python 3.12.3 

**Destination channel:** Defaults

### Links

- [PKG-5995]
- dev_url:        https://github.com/snowflakedb/snowflake-connector-python/tree/v3.12.3
- conda_forge:    https://github.com/conda-forge/snowflake-connector-python-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/snowflake-connector-python/3.12.3/
- pypi inspector: https://inspector.pypi.io/project/snowflake-connector-python/3.12.3

### Explanation of changes:

- new version number


[PKG-5995]: https://anaconda.atlassian.net/browse/PKG-5995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ