### PR TITLE
snowflake-connector-python 3.12.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "3.12.3" %}
+{% set version = "3.12.4" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   # use GH release sources to use tests
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 596832b7ecde1cef46d1aaab61f2b38783509b1a4dd91df18645184f762b73ae
+  sha256: 0591da1a9aa66543ab5d82d97e3e3548c5f9ae208ade6f31a1d810d128a08994
   
 build:
   number: 100
@@ -37,7 +37,7 @@ requirements:
     - asn1crypto >0.24.0,<2.0.0
     - cffi >=1.9,<2.0.0
     - cryptography >=3.1.0
-    - pyopenssl >=16.2.0,<25.0.0
+    - pyopenssl >=22.0.0,<25.0.0
     - pyjwt <3.0.0
     - pytz
     - requests <3.0.0


### PR DESCRIPTION
snowflake-connector-python 3.12.4

**Destination channel:** defaults

### Links

- [PKG-6419]
- dev_url (pypi): https://github.com/snowflakedb/snowflake-connector-python/tree/v3.12.4
- diff: https://github.com/snowflakedb/snowflake-connector-python/compare/v3.12.3...v3.12.4
- conda-forge: https://github.com/conda-forge/snowflake-connector-python-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/snowflake-connector-python/3.12.4
- pypi inspector: https://inspector.pypi.io/project/snowflake-connector-python/3.12.4

### Explanation of changes:

- bump version
- update pinning for `pyOpenSSL >=22.0.0,<25.0.0`
- staple SF package: build number must be `>=100`


[PKG-6419]: https://anaconda.atlassian.net/browse/PKG-6419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ