### PR TITLE
snowflake-connector-python 3.13.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,6 +78,7 @@ test:
   imports:
     - snowflake
     - snowflake.connector
+    - snowflake.connector.auth
     - snowflake.connector.nanoarrow_arrow_iterator
   requires:
     - pip
@@ -87,6 +88,9 @@ test:
     - test/data/cert_tests/incomplete-chain.pem
   commands:
     - pip check
+    - snowflake-dump-ocsp-response --help
+    - snowflake-dump-ocsp-response-cache --help
+    - snowflake-dump-certs --help
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest -v test/unit {{ tests_to_ignore }} {{ tests_to_deselect }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,11 +88,6 @@ test:
     - test/data/cert_tests/incomplete-chain.pem
   commands:
     - pip check
-    # These tools will only output the `help` if less args than expected are given
-    # So we call them with no args, and expect return code 2, which they will return when no args are provided
-    - snowflake-dump-ocsp-response || true
-    - snowflake-dump-ocsp-response-cache || true
-    - snowflake-dump-certs || true
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest -v test/unit {{ tests_to_ignore }} {{ tests_to_deselect }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,9 +88,11 @@ test:
     - test/data/cert_tests/incomplete-chain.pem
   commands:
     - pip check
-    - snowflake-dump-ocsp-response --help
-    - snowflake-dump-ocsp-response-cache --help
-    - snowflake-dump-certs --help
+    # These tools will only output the `help` if less args than expected are given
+    # So we call them with no args
+    - snowflake-dump-ocsp-response
+    - snowflake-dump-ocsp-response-cache
+    - snowflake-dump-certs
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest -v test/unit {{ tests_to_ignore }} {{ tests_to_deselect }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "3.12.4" %}
+{% set version = "3.13.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   # use GH release sources to use tests
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0591da1a9aa66543ab5d82d97e3e3548c5f9ae208ade6f31a1d810d128a08994
+  sha256: 540ab4847892d76d95c994d9297378a6473bd89aedb696c066464896cff266e1
   
 build:
   number: 100
@@ -20,7 +20,6 @@ build:
     - snowflake-dump-ocsp-response = snowflake.connector.tool.dump_ocsp_response:main
     - snowflake-dump-ocsp-response-cache = snowflake.connector.tool.dump_ocsp_response_cache:main
     - snowflake-dump-certs = snowflake.connector.tool.dump_certs:main
-    - snowflake-export-certs = snowflake.connector.tool.export_certs:main
 
 requirements:
   build:
@@ -41,7 +40,6 @@ requirements:
     - pyjwt <3.0.0
     - pytz
     - requests <3.0.0
-    - importlib-metadata  # [py<38]
     - packaging
     - charset-normalizer >=2,<4
     - idna >=2.5,<4
@@ -59,24 +57,23 @@ requirements:
 # ignore these unit tests because they use relative imports
 # or not found modules (existing but not well configured).
 {% set tests_to_ignore = "" %}
-# update: they still fail for 3.11.0
+# update: they still fail for 3.13.0
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_configmanager.py" %}
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_connection.py" %}
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_encryption_util.py" %}
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_error_arrow_stream.py" %}
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_result_batch.py" %}
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_s3_util.py" %}
-# ignore this test because it takes a lot (retry/timeout network tests)
-{% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_retry_network.py" %}
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_network.py" %}
+
 
 {% set tests_to_deselect = "" %}
 # linux: deselect the following tests because file permissions 
 # will not be set correctly and fail with DID NOT RAISE PermissionError
 # update: they still fail for 3.11.0
-{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_cache.py::TestSFDictFileCache::test_read_only" %}        # [linux]
-{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_easy_logging.py::test_config_file_inaccessible_path" %}  # [linux]
-{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_put_get.py::test_put_error" %}                           # [linux]
+#{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_cache.py::TestSFDictFileCache::test_read_only" %}        # [linux]
+#{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_easy_logging.py::test_config_file_inaccessible_path" %}  # [linux]
+#{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_put_get.py::test_put_error" %}                           # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,9 +54,9 @@ requirements:
     - pandas >=1.0.0,<3.0.0
     - keyring >=23.1.0,<26.0.0
 
+{% set tests_to_ignore = "" %}
 # ignore these unit tests because they use relative imports
 # or not found modules (existing but not well configured).
-{% set tests_to_ignore = "" %}
 # update: they still fail for 3.13.0
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_configmanager.py" %}
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_connection.py" %}
@@ -66,14 +66,13 @@ requirements:
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_s3_util.py" %}
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/unit/test_network.py" %}
 
-
 {% set tests_to_deselect = "" %}
 # linux: deselect the following tests because file permissions 
 # will not be set correctly and fail with DID NOT RAISE PermissionError
-# update: they still fail for 3.11.0
-#{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_cache.py::TestSFDictFileCache::test_read_only" %}        # [linux]
-#{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_easy_logging.py::test_config_file_inaccessible_path" %}  # [linux]
-#{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_put_get.py::test_put_error" %}                           # [linux]
+# update: they still fail for 3.13.0
+{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_cache.py::TestSFDictFileCache::test_read_only" %}        # [linux]
+{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_easy_logging.py::test_config_file_inaccessible_path" %}  # [linux]
+{% set tests_to_deselect = tests_to_deselect + " --deselect=test/unit/test_put_get.py::test_put_error" %}                           # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,10 +89,10 @@ test:
   commands:
     - pip check
     # These tools will only output the `help` if less args than expected are given
-    # So we call them with no args
-    - snowflake-dump-ocsp-response
-    - snowflake-dump-ocsp-response-cache
-    - snowflake-dump-certs
+    # So we call them with no args, and expect return code 2, which they will return when no args are provided
+    - snowflake-dump-ocsp-response || true
+    - snowflake-dump-ocsp-response-cache || true
+    - snowflake-dump-certs || true
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest -v test/unit {{ tests_to_ignore }} {{ tests_to_deselect }}
 


### PR DESCRIPTION
snowflake-connector-python 3.13.0 

**Destination channel:** Defaults

### Links

- [PKG-6880]
- dev_url:        https://github.com/snowflakedb/snowflake-connector-python/tree/v3.12.4
- conda_forge:    https://github.com/conda-forge/snowflake-connector-python-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/snowflake-connector-python/3.12.4
- pypi inspector: https://inspector.pypi.io/project/snowflake-connector-python/3.12.4

### Explanation of changes:

- New version number
- Removed obsolete `entry_point`
- Removed `importlib-metadata` as it is only need in python versions *not* supported by the package
- Restored `test_retry_network.py`, as it doesn't appear to fail


[PKG-6880]: https://anaconda.atlassian.net/browse/PKG-6880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ