### PR TITLE
snowflake-connector-python 3.13.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "3.13.1" %}
+{% set version = "3.13.2" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   # use GH release sources to use tests
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7971949abe231c645d162c26769d64c51b716ed4bff5d5312ff3135abf9a0f50
+  sha256: 11b48de078f603058a64154d3a6191f52564479a52ce26b7e88ecc3ded8ee4a4
   
 build:
   number: 100


### PR DESCRIPTION
snowflake-connector-python 3.13.2 

**Destination channel:** Defaults

### Links

- [PKG-6960]
- dev_url:        https://github.com/snowflakedb/snowflake-connector-python/tree/v3.13.2
- conda_forge:    None
- pypi:           https://pypi.org/project/snowflake-connector-python/3.13.2
- pypi inspector: https://inspector.pypi.io/project/snowflake-connector-python/3.13.2
- diff (no dep changes): https://github.com/snowflakedb/snowflake-connector-python/compare/v3.13.1...v3.13.2

### Explanation of changes:

- new version number


[PKG-6960]: https://anaconda.atlassian.net/browse/PKG-6960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ