### PR TITLE
snowflake-connector-python 3.15 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-connector-python" %}
-{% set version = "3.14.1" %}
+{% set version = "3.15.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   # use GH release sources to use tests
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 87de09a6a224f095dc25caf17c40c36d076cfdeca34598b0671b792886ed765e
+  sha256: a7ae82f22adf30d0b802922311abc42669ad3ec3f4e7adc69395b753a6f1a0ac
   
 build:
   number: 100
@@ -33,8 +33,8 @@ requirements:
   run:
     - python
     - asn1crypto >0.24.0,<2.0.0
-    - boto3 >=1.0
-    - botocore >=1.0
+    - boto3 >=1.24
+    - botocore >=1.24
     - cffi >=1.9,<2.0.0
     - cryptography >=3.1.0
     - pyopenssl >=22.0.0,<26.0.0


### PR DESCRIPTION
snowflake-connector-python 3.15 

**Destination channel:** Defaults

### Links

- [PKG-8146]
- dev_url:        https://github.com/snowflakedb/snowflake-connector-python/tree/v3.14.0
- conda_forge:    None
- pypi:           https://pypi.org/project/snowflake-connector-python/3.14.0
- pypi inspector: https://inspector.pypi.io/project/snowflake-connector-python/3.14.0

### Explanation of changes:

- new version number
